### PR TITLE
refactor _fit function

### DIFF
--- a/src/models/PartialCreditModel.jl
+++ b/src/models/PartialCreditModel.jl
@@ -6,6 +6,8 @@ A type representing a Partial Credit Model.
 struct PartialCreditModel{ET<:EstimationType,DT<:AbstractMatrix,PT} <: PolytomousRaschModel{ET,PT}
     data::DT
     pars::PT
+    parnames_beta::Vector{Symbol}
+    parnames_tau::Vector{Vector{Symbol}}
 end
 
 function _get_item_thresholds(model::PartialCreditModel{ET,DT,PT}, i)::Matrix{Float64} where {ET,DT,PT<:Chains}

--- a/src/models/RaschModel.jl
+++ b/src/models/RaschModel.jl
@@ -1,6 +1,7 @@
 mutable struct RaschModel{ET<:EstimationType,DT<:AbstractMatrix,PT} <: AbstractRaschModel
     data::DT
     pars::PT
+    parnames::Vector{Symbol}
 end
 
 response_type(::Type{<:RaschModel}) = AbstractItemResponseModels.Dichotomous

--- a/src/models/RatingScaleModel.jl
+++ b/src/models/RatingScaleModel.jl
@@ -6,6 +6,8 @@ A type representing a Rating Scale Model
 struct RatingScaleModel{ET<:EstimationType,DT<:AbstractMatrix,PT} <: PolytomousRaschModel{ET,PT}
     data::DT
     pars::PT
+    parnames_beta::Vector{Symbol}
+    parnames_tau::Vector{Symbol}
 end
 
 function _get_item_thresholds(model::RatingScaleModel{ET,DT,PT}, i)::Matrix{Float64} where {ET,DT,PT<:Chains}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -35,3 +35,22 @@ function construct_response_vector(m::AbstractMatrix{Union{Missing,T}}, N; dropm
     type = dropmissing ? T : Union{Missing,T}
     return Vector{type}(undef, N)
 end
+
+"""
+    betnames(n)
+
+Construct a vector of parameter names for item difficulties/locations.
+"""
+function betanames(n)
+    return [Symbol("beta[", i, "]") for i in 1:n]
+end
+
+"""
+    taunames(n; item=nothing)
+
+Construct a vector of parameter names for item thresholds.
+"""
+function taunames(n; item=nothing)
+    item_str = isnothing(item) ? "" : string("[", item, "]")
+    return [Symbol("tau", item_str, "[", i, "]") for i in 1:n]
+end

--- a/test/models/PartialCreditModel.jl
+++ b/test/models/PartialCreditModel.jl
@@ -1,0 +1,11 @@
+@testset "PartialCreditModel" begin
+    data = rand(1:3, 100, 2)
+
+    pcm_mle = fit(PartialCreditModel, data, MLE())
+    @test estimation_type(pcm_mle) == PointEstimate
+    @test pcm_mle.parnames_beta == [Symbol("beta[1]"), Symbol("beta[2]")]
+    @test pcm_mle.parnames_tau == [
+        [Symbol("tau[1][1]"), Symbol("tau[1][2]")],
+        [Symbol("tau[2][1]"), Symbol("tau[2][2]")]
+    ]
+end

--- a/test/models/RaschModel.jl
+++ b/test/models/RaschModel.jl
@@ -3,6 +3,14 @@
     model_mcmc = fit(RaschModel, X, MH(), 100)
     model_mle = fit(RaschModel, X, MLE())
 
+    @testset "Model construction" begin
+        @test estimation_type(model_mcmc) == SamplingEstimate
+        @test model_mcmc.parnames == [Symbol("beta[1]"), Symbol("beta[2]"), Symbol("beta[3]")]
+
+        @test estimation_type(model_mle) == PointEstimate
+        @test model_mle.parnames == [Symbol("beta[1]"), Symbol("beta[2]"), Symbol("beta[3]")]
+    end
+
     @testset "irf" begin
         @test RaschModels._irf(RaschModel, 0.0, 0.0, 0) == RaschModels._irf(RaschModel, 0.0, 0.0, 1)
         @test RaschModels._irf(RaschModel, 0.0, 0.0, 1) == 0.5

--- a/test/models/RatingScaleModel.jl
+++ b/test/models/RatingScaleModel.jl
@@ -1,0 +1,13 @@
+@testset "RatingScaleModel" begin
+    data = rand(1:3, 100, 2)
+
+    rsm_mle = fit(RatingScaleModel, data, MLE())
+    @test estimation_type(rsm_mle) == PointEstimate
+    @test rsm_mle.parnames_beta == [Symbol("beta[1]"), Symbol("beta[2]")]
+    @test rsm_mle.parnames_tau == [Symbol("tau[1]"), Symbol("tau[2]")]
+
+    rsm_mcmc = fit(RatingScaleModel, data, MH(), 100)
+    @test estimation_type(rsm_mcmc) == SamplingEstimate
+    @test rsm_mcmc.parnames_beta == [Symbol("beta[1]"), Symbol("beta[2]")]
+    @test rsm_mcmc.parnames_tau == [Symbol("tau[1]"), Symbol("tau[2]")]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,8 +10,9 @@ Turing.setprogress!(false)
 
 @testset "RaschModels.jl" begin
     include("utils.jl")
-
     include("test_interface.jl")
     include("models/RaschModel.jl")
     include("models/PolytomousRaschModel.jl")
+    include("models/RatingScaleModel.jl")
+    include("models/PartialCreditModel.jl")
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -23,4 +23,15 @@
         @test long_nodropped_missing[2] == [1, 1, 2, 2]
         @test long_nodropped_missing[3] == [1, 2, 1, 2]
     end
+
+    @testset "betanames" begin
+        @test RaschModels.betanames(1) == [Symbol("beta[1]")]
+        @test RaschModels.betanames(2) == [Symbol("beta[1]"), Symbol("beta[2]")]
+    end
+
+    @testset "taunames" begin
+        @test RaschModels.taunames(1) == [Symbol("tau[1]")]
+        @test RaschModels.taunames(2) == [Symbol("tau[1]"), Symbol("tau[2]")]
+        @test RaschModels.taunames(2, item=1) == [Symbol("tau[1][1]"), Symbol("tau[1][2]")]
+    end
 end


### PR DESCRIPTION
This pull request refactors the `_fit` function to allow construction for different model types.

It is done by dispatching on `modeltype` first, and defining a algorithm specific `_fit_by_alg` function that dispatches based on `alg`. This should allow reuse of the majority of fitting code while allowing construction for concrete model implementations. 

Different model constructors are necessary for performance optimizations in https://github.com/JuliaPsychometrics/RaschModels.jl/pull/23 to preallocate variable names in the various model structs.
